### PR TITLE
changes for parsnip 1.2.1.9004

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,8 @@ Suggests:
     workflows,
     rsample,
     xgboost
+Remotes:
+    tidymodels/parsnip
 Config/testthat/edition: 3
 Depends: 
     R (>= 4.1)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,11 +16,11 @@ URL: https://github.com/mattheaphy/offsetreg/, https://mattheaphy.github.io/offs
 BugReports: https://github.com/mattheaphy/offsetreg/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.2
 Imports: 
     generics,
     glue,
-    parsnip (>= 1.2.0),
+    parsnip (>= 1.2.1.9004),
     poissonreg,
     rlang,
     stats

--- a/R/boost_tree_offset.R
+++ b/R/boost_tree_offset.R
@@ -104,7 +104,7 @@ update.boost_tree_offset <- function(object,
 
 # code from the parsnip package
 #' @export
-check_args.boost_tree_offset <- function(object) {
+check_args.boost_tree_offset <- function(object, call = NULL) {
 
   args <- lapply(object$args, rlang::eval_tidy)
 

--- a/R/poisson_reg_offset.R
+++ b/R/poisson_reg_offset.R
@@ -61,7 +61,7 @@ translate.poisson_reg_offset <- function (x, engine = x$engine, ...) {
 
 # code from the parsnip package
 #' @export
-check_args.poisson_reg_offset <- function(object) {
+check_args.poisson_reg_offset <- function(object, call = NULL) {
 
   args <- lapply(object$args, rlang::eval_tidy)
 

--- a/offsetreg.Rproj
+++ b/offsetreg.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 60482197-118e-4742-b54e-16bd1d0eb1f8
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
We'll be making a parsnip release soon and there were some changes to one of the parsnip generics. We get the offsetreg error of: 

```
## Newly broken

*   checking tests ...

      Running ‘testthat.R’
     ERROR
    Running the tests in ‘tests/testthat.R’ failed.
    Last 13 lines of output:
        4.     ├─generics::fit(action_model, workflow = workflow, control = control)
        5.     └─workflows:::fit.action_model(...)
        6.       └─workflows:::fit_from_xy(spec, mold, case_weights, control_parsnip)
        7.         ├─generics::fit_xy(...)
        8.         └─parsnip::fit_xy.model_spec(...)
        9.           └─parsnip:::xy_xy(...)
       10.             └─parsnip::check_args(object, call = call)
      ── Failure ('test-xgboost.R:137:3'): finalize works ────────────────────────────
      Expected `fit(tune::finalize_workflow(wf, param_grid), us_deaths)` to run without any errors.
      i Actually got a <simpleError> with text:
        unused argument (call = call)
      
      [ FAIL 6 | WARN 0 | SKIP 0 | PASS 32 ]
      Error: Test failures
      Execution halted
```

Once parsnip is on CRAN, you can remove the `remote` entry in the description file. 

Sorry for the nuisance! 
  