### PR TITLE
Compatibility update for parsnip 1.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: offsetreg
 Title: An Extension of 'Tidymodels' Supporting Offset Terms
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: 
     person("Matt", "Heaphy", email = "mattrmattrs@gmail.com", role = c("aut", "cre", "cph"))
 Maintainer: Matt Heaphy <mattrmattrs@gmail.com>    

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ RoxygenNote: 7.3.2
 Imports: 
     generics,
     glue,
-    parsnip (>= 1.2.1.9004),
+    parsnip (>= 1.3.0),
     poissonreg,
     rlang,
     stats
@@ -36,8 +36,6 @@ Suggests:
     workflows,
     rsample,
     xgboost
-Remotes:
-    tidymodels/parsnip
 Config/testthat/edition: 3
 Depends: 
     R (>= 4.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# offsetreg 1.1.1
+
+- Behind-the-scenes compatibility update for parsnip 1.3.0, which is now the minimum required version.
+
 # offsetreg 1.1.0
 
 - `boost_tree_offset()` - new model specification for boosted ensembles of decision trees. Currently xgboost ("xgboost_offset") is supported.


### PR DESCRIPTION
- Removed remote in DESCRIPTION after parsnip 1.3.0 was published to CRAN.
- Incremented version number