### PR TITLE
offsetreg 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL: https://github.com/mattheaphy/offsetreg/, https://mattheaphy.github.io/offs
 BugReports: https://github.com/mattheaphy/offsetreg/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports: 
     generics,
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Imports: 
+    cli,
     generics,
     glue,
     parsnip (>= 1.3.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: offsetreg
 Title: An Extension of 'Tidymodels' Supporting Offset Terms
-Version: 1.1.1
+Version: 1.1.1.9000
 Authors@R: 
     person("Matt", "Heaphy", email = "mattrmattrs@gmail.com", role = c("aut", "cre", "cph"))
 Maintainer: Matt Heaphy <mattrmattrs@gmail.com>    

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: offsetreg
 Title: An Extension of 'Tidymodels' Supporting Offset Terms
-Version: 1.1.1.9000
+Version: 1.2.0
 Authors@R: 
     person("Matt", "Heaphy", email = "mattrmattrs@gmail.com", role = c("aut", "cre", "cph"))
 Maintainer: Matt Heaphy <mattrmattrs@gmail.com>    

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests:
     tune,
     workflows,
     rsample,
-    xgboost
+    xgboost (>= 3.0.0)
 Config/testthat/edition: 3
 Depends: 
     R (>= 4.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # offsetreg 1.2.0
 
 - Added support for additional named arguments passed to `stats::glm()` in `glm_offset()` and `glmnet::glmnet()` in `glmnet_offset()`.
+- Added the `cli` package for warning and error messages.
 
 # offsetreg 1.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# offsetreg 1.2.0
+
+- Added support for additional named arguments passed to `stats::glm()` in `glm_offset()` and `glmnet::glmnet()` in `glmnet_offset()`.
+
 # offsetreg 1.1.1
 
 - Behind-the-scenes compatibility update for parsnip 1.3.0, which is now the minimum required version.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # offsetreg 1.2.0
 
 - Added support for additional named arguments passed to `stats::glm()` in `glm_offset()` and `glmnet::glmnet()` in `glmnet_offset()`.
+- Updated the minimum required version of `xgboost` to 3.0 and made behind-the-scenes changes to accomodate its updated API.
 - Added the `cli` package for warning and error messages.
 
 # offsetreg 1.1.1

--- a/R/boost_tree_data.R
+++ b/R/boost_tree_data.R
@@ -1,9 +1,9 @@
 make_boost_tree_xgboost_offset <- function() {
-
   set_model_engine(
     "boost_tree_offset",
     mode = "regression",
-    eng = "xgboost_offset")
+    eng = "xgboost_offset"
+  )
 
   set_dependency(
     "boost_tree_offset",
@@ -84,7 +84,6 @@ make_boost_tree_xgboost_offset <- function() {
     has_submodel = FALSE
   )
 
-
   set_fit(
     model = "boost_tree_offset",
     eng = "xgboost_offset",
@@ -118,8 +117,11 @@ make_boost_tree_xgboost_offset <- function() {
       pre = .predict_pre_offset_rename,
       post = NULL,
       func = c(fun = "xgb_predict_offset"),
-      args = list(object = expr(object$fit), new_data = expr(new_data),
-                  offset_col = "offset")
+      args = list(
+        object = expr(object$fit),
+        new_data = expr(new_data),
+        offset_col = "offset"
+      )
     )
   )
 
@@ -132,9 +134,11 @@ make_boost_tree_xgboost_offset <- function() {
       pre = .predict_pre_offset_rename,
       post = NULL,
       func = c(fun = "xgb_predict_offset"),
-      args = list(object = expr(object$fit), new_data = expr(new_data),
-                  offset_col = "offset")
+      args = list(
+        object = expr(object$fit),
+        new_data = expr(new_data),
+        offset_col = "offset"
+      )
     )
   )
-
 }

--- a/R/boost_tree_offset.R
+++ b/R/boost_tree_offset.R
@@ -23,28 +23,32 @@
 #'
 #' @seealso [parsnip::boost_tree()]
 #' @export
-boost_tree_offset <- function(mode = "regression",
-                              engine = "xgboost_offset",
-                              mtry = NULL,
-                              trees = NULL,
-                              min_n = NULL,
-                              tree_depth = NULL,
-                              learn_rate = NULL,
-                              loss_reduction = NULL,
-                              sample_size = NULL,
-                              stop_iter = NULL) {
-
-  if (mode  != "regression") {
+boost_tree_offset <- function(
+  mode = "regression",
+  engine = "xgboost_offset",
+  mtry = NULL,
+  trees = NULL,
+  min_n = NULL,
+  tree_depth = NULL,
+  learn_rate = NULL,
+  loss_reduction = NULL,
+  sample_size = NULL,
+  stop_iter = NULL
+) {
+  if (mode != "regression") {
     rlang::abort("`mode` should be 'regression'")
   }
 
-  args <- list(mtry = rlang::enquo(mtry), trees = rlang::enquo(trees),
-               min_n = rlang::enquo(min_n),
-               tree_depth = rlang::enquo(tree_depth),
-               learn_rate = rlang::enquo(learn_rate),
-               loss_reduction = rlang::enquo(loss_reduction),
-               sample_size = rlang::enquo(sample_size),
-               stop_iter = rlang::enquo(stop_iter))
+  args <- list(
+    mtry = rlang::enquo(mtry),
+    trees = rlang::enquo(trees),
+    min_n = rlang::enquo(min_n),
+    tree_depth = rlang::enquo(tree_depth),
+    learn_rate = rlang::enquo(learn_rate),
+    loss_reduction = rlang::enquo(loss_reduction),
+    sample_size = rlang::enquo(sample_size),
+    stop_iter = rlang::enquo(stop_iter)
+  )
 
   # Save some empty slots for future parts of the specification
   new_model_spec(
@@ -73,14 +77,20 @@ print.boost_tree_offset <- function(x, ...) {
 
 # code from the parsnip package
 #' @export
-update.boost_tree_offset <- function(object,
-                              parameters = NULL,
-                              mtry = NULL, trees = NULL, min_n = NULL,
-                              tree_depth = NULL, learn_rate = NULL,
-                              loss_reduction = NULL, sample_size = NULL,
-                              stop_iter = NULL,
-                              fresh = FALSE, ...) {
-
+update.boost_tree_offset <- function(
+  object,
+  parameters = NULL,
+  mtry = NULL,
+  trees = NULL,
+  min_n = NULL,
+  tree_depth = NULL,
+  learn_rate = NULL,
+  loss_reduction = NULL,
+  sample_size = NULL,
+  stop_iter = NULL,
+  fresh = FALSE,
+  ...
+) {
   args <- list(
     mtry = rlang::enquo(mtry),
     trees = rlang::enquo(trees),
@@ -105,13 +115,15 @@ update.boost_tree_offset <- function(object,
 # code from the parsnip package
 #' @export
 check_args.boost_tree_offset <- function(object, call = NULL) {
-
   args <- lapply(object$args, rlang::eval_tidy)
 
   if (is.numeric(args$trees) && args$trees < 0) {
     rlang::abort("`trees` should be >= 1.")
   }
-  if (is.numeric(args$sample_size) && (args$sample_size < 0 | args$sample_size > 1)) {
+  if (
+    is.numeric(args$sample_size) &&
+      (args$sample_size < 0 | args$sample_size > 1)
+  ) {
     rlang::abort("`sample_size` should be within [0,1].")
   }
   if (is.numeric(args$tree_depth) && args$tree_depth < 0) {

--- a/R/boost_tree_offset.R
+++ b/R/boost_tree_offset.R
@@ -36,7 +36,7 @@ boost_tree_offset <- function(
   stop_iter = NULL
 ) {
   if (mode != "regression") {
-    rlang::abort("`mode` should be 'regression'")
+    cli::cli_abort("`mode` should be 'regression'")
   }
 
   args <- list(
@@ -118,19 +118,19 @@ check_args.boost_tree_offset <- function(object, call = NULL) {
   args <- lapply(object$args, rlang::eval_tidy)
 
   if (is.numeric(args$trees) && args$trees < 0) {
-    rlang::abort("`trees` should be >= 1.")
+    cli::cli_abort("`trees` should be >= 1.")
   }
   if (
     is.numeric(args$sample_size) &&
       (args$sample_size < 0 | args$sample_size > 1)
   ) {
-    rlang::abort("`sample_size` should be within [0,1].")
+    cli::cli_abort("`sample_size` should be within [0,1].")
   }
   if (is.numeric(args$tree_depth) && args$tree_depth < 0) {
-    rlang::abort("`tree_depth` should be >= 1.")
+    cli::cli_abort("`tree_depth` should be >= 1.")
   }
   if (is.numeric(args$min_n) && args$min_n < 0) {
-    rlang::abort("`min_n` should be >= 1.")
+    cli::cli_abort("`min_n` should be >= 1.")
   }
 
   invisible(object)

--- a/R/decision_tree_data.R
+++ b/R/decision_tree_data.R
@@ -1,9 +1,9 @@
 make_decision_tree_rpart_exposure <- function() {
-
   set_model_engine(
     "decision_tree_exposure",
     mode = "regression",
-    eng = "rpart_exposure")
+    eng = "rpart_exposure"
+  )
 
   set_dependency(
     "decision_tree_exposure",
@@ -79,8 +79,7 @@ make_decision_tree_rpart_exposure <- function() {
       pre = NULL,
       post = NULL,
       func = c(fun = "predict"),
-      args = c(object = expr(object$fit),
-               newdata = expr(new_data))
+      args = c(object = expr(object$fit), newdata = expr(new_data))
     )
   )
 
@@ -93,8 +92,7 @@ make_decision_tree_rpart_exposure <- function() {
       pre = NULL,
       post = NULL,
       func = c(fun = "predict"),
-      args = c(object = expr(object$fit),
-               newdata = expr(new_data))
+      args = c(object = expr(object$fit), newdata = expr(new_data))
     )
   )
 }

--- a/R/decision_tree_exposure.R
+++ b/R/decision_tree_exposure.R
@@ -28,7 +28,7 @@ decision_tree_exposure <- function(
   min_n = NULL
 ) {
   if (mode != "regression") {
-    rlang::abort("`mode` should be 'regression'")
+    cli::cli_abort("`mode` should be 'regression'")
   }
 
   args <- list(

--- a/R/decision_tree_exposure.R
+++ b/R/decision_tree_exposure.R
@@ -20,19 +20,22 @@
 #' @inheritParams parsnip::decision_tree
 #' @seealso [parsnip::decision_tree()]
 #' @export
-decision_tree_exposure <- function(mode = "regression",
-                                   engine = "rpart_exposure",
-                                   cost_complexity = NULL,
-                                   tree_depth = NULL,
-                                   min_n = NULL) {
-
-  if (mode  != "regression") {
+decision_tree_exposure <- function(
+  mode = "regression",
+  engine = "rpart_exposure",
+  cost_complexity = NULL,
+  tree_depth = NULL,
+  min_n = NULL
+) {
+  if (mode != "regression") {
     rlang::abort("`mode` should be 'regression'")
   }
 
-  args <- list(cost_complexity = rlang::enquo(cost_complexity),
-               tree_depth = rlang::enquo(tree_depth),
-               min_n = rlang::enquo(min_n))
+  args <- list(
+    cost_complexity = rlang::enquo(cost_complexity),
+    tree_depth = rlang::enquo(tree_depth),
+    min_n = rlang::enquo(min_n)
+  )
 
   # Save some empty slots for future parts of the specification
   new_model_spec(
@@ -56,16 +59,20 @@ make_decision_tree_exposure <- function() {
 
 # code from the parsnip package
 #' @export
-update.decision_tree_exposure <- function(object,
-                                      parameters = NULL,
-                                      cost_complexity = NULL,
-                                      tree_depth = NULL,
-                                      min_n = NULL,
-                                      fresh = FALSE, ...) {
-
-  args <- list(cost_complexity = rlang::enquo(cost_complexity),
-               tree_depth = rlang::enquo(tree_depth),
-               min_n = rlang::enquo(min_n))
+update.decision_tree_exposure <- function(
+  object,
+  parameters = NULL,
+  cost_complexity = NULL,
+  tree_depth = NULL,
+  min_n = NULL,
+  fresh = FALSE,
+  ...
+) {
+  args <- list(
+    cost_complexity = rlang::enquo(cost_complexity),
+    tree_depth = rlang::enquo(tree_depth),
+    min_n = rlang::enquo(min_n)
+  )
 
   update_spec(
     object = object,

--- a/R/glm.R
+++ b/R/glm.R
@@ -48,10 +48,10 @@ glm_offset <- function(
   ...
 ) {
   if (!is.data.frame(data)) {
-    rlang::abort("`data` must be a data frame.")
+    cli::cli_abort("`data` must be a data frame.")
   }
   if (!offset_col %in% names(data)) {
-    rlang::abort(glue("A column named `{offset_col}` must be present."))
+    cli::cli_abort("A column named `{offset_col}` must be present.")
   }
 
   # rename the offset column

--- a/R/glm.R
+++ b/R/glm.R
@@ -22,6 +22,7 @@
 #' @param offset_col Character string. The name of a column in `data` containing
 #' offsets.
 #' @param weights Optional weights to use in the fitting process.
+#' @param ... Additional named arguments passed to [stats::glm()].
 #'
 #' @returns A `glm` object. See [stats::glm()] for full details.
 #'
@@ -39,7 +40,8 @@ glm_offset <- function(
   family = "gaussian",
   data,
   offset_col = "offset",
-  weights = NULL
+  weights = NULL,
+  ...
 ) {
   if (!is.data.frame(data)) {
     rlang::abort("`data` must be a data frame.")
@@ -60,7 +62,8 @@ glm_offset <- function(
     family = family,
     offset = offset,
     data = data,
-    weights = weights
+    weights = weights,
+    ...
   )
 }
 

--- a/R/glm.R
+++ b/R/glm.R
@@ -29,8 +29,12 @@
 #' @examples
 #' if (interactive()) {
 #'   us_deaths$off <- log(us_deaths$population)
-#'   glm_offset(deaths ~ age_group + gender, family = "poisson",
-#'              us_deaths, offset_col = "off")
+#'   glm_offset(
+#'     deaths ~ age_group + gender,
+#'     family = "poisson",
+#'     us_deaths,
+#'     offset_col = "off"
+#'   )
 #' }
 #'
 #' @seealso [stats::glm()]

--- a/R/glm.R
+++ b/R/glm.R
@@ -34,9 +34,13 @@
 #'
 #' @seealso [stats::glm()]
 #' @export
-glm_offset <- function(formula, family = "gaussian", data,
-                       offset_col = "offset", weights = NULL) {
-
+glm_offset <- function(
+  formula,
+  family = "gaussian",
+  data,
+  offset_col = "offset",
+  weights = NULL
+) {
   if (!is.data.frame(data)) {
     rlang::abort("`data` must be a data frame.")
   }
@@ -51,12 +55,13 @@ glm_offset <- function(formula, family = "gaussian", data,
 
   # bind weights to the formula's environment to avoid an error in model.frame
   rlang::env_bind(environment(formula), weights = weights)
-  stats::glm(formula,
-             family = family,
-             offset = offset,
-             data = data,
-             weights = weights)
-
+  stats::glm(
+    formula,
+    family = family,
+    offset = offset,
+    data = data,
+    weights = weights
+  )
 }
 
 # internal function used to rename the specified offset column to "offset"
@@ -79,8 +84,7 @@ glm_offset <- function(formula, family = "gaussian", data,
   if (grepl("(\\s|^)\\.(\\s|$)", formula_str[[3]])) {
     # string manipulation is required because R will return an error
     # if update is called on a formula with `.` on the RHS
-    paste(formula_str[[2]], "~",
-          formula_str[[3]], "-", x) |>
+    paste(formula_str[[2]], "~", formula_str[[3]], "-", x) |>
       stats::as.formula()
   } else {
     stats::update(formula, paste("~ . -", x))

--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -35,9 +35,15 @@
 #'
 #' @seealso [glmnet::glmnet()]
 #' @export
-glmnet_offset <- function(x, y, family, offset_col = "offset",
-                          weights = NULL, lambda = NULL, alpha = 1) {
-
+glmnet_offset <- function(
+  x,
+  y,
+  family,
+  offset_col = "offset",
+  weights = NULL,
+  lambda = NULL,
+  alpha = 1
+) {
   rlang::check_installed("glmnet")
 
   if (!offset_col %in% colnames(x)) {
@@ -47,10 +53,15 @@ glmnet_offset <- function(x, y, family, offset_col = "offset",
   offsets <- x[, offset_col]
   x <- x[, !colnames(x) %in% offset_col, drop = FALSE]
 
-  glmnet::glmnet(x, y, family = family, weights, offset = offsets,
-                 lambda = lambda,
-                 alpha = alpha)
-
+  glmnet::glmnet(
+    x,
+    y,
+    family = family,
+    weights,
+    offset = offsets,
+    lambda = lambda,
+    alpha = alpha
+  )
 }
 
 # code from the parsnip package

--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -49,7 +49,7 @@ glmnet_offset <- function(
   rlang::check_installed("glmnet")
 
   if (!offset_col %in% colnames(x)) {
-    rlang::abort(glue("A column named `{offset_col}` must be present."))
+    cli::cli_abort("A column named `{offset_col}` must be present.")
   }
 
   offsets <- x[, offset_col]

--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -22,6 +22,7 @@
 #' (lasso) versus L2 (ridge) regularization.
 #' - `alpha = 1`: Pure lasso model
 #' - `alpha = 0`: Pure ridge model
+#' @param ... Additional named arguments passed to [glmnet::glmnet()].
 #' @inheritParams glm_offset
 #'
 #' @returns A `glmnet` object. See [glmnet::glmnet()] for full details.
@@ -42,7 +43,8 @@ glmnet_offset <- function(
   offset_col = "offset",
   weights = NULL,
   lambda = NULL,
-  alpha = 1
+  alpha = 1,
+  ...
 ) {
   rlang::check_installed("glmnet")
 
@@ -60,7 +62,8 @@ glmnet_offset <- function(
     weights,
     offset = offsets,
     lambda = lambda,
-    alpha = alpha
+    alpha = alpha,
+    ...
   )
 }
 

--- a/R/poisson_reg_data.R
+++ b/R/poisson_reg_data.R
@@ -11,17 +11,20 @@ make_poisson_reg_glm_offset <- function() {
     "poisson_reg_offset",
     eng = "glm_offset",
     pkg = "stats",
-    mode = "regression")
+    mode = "regression"
+  )
   set_dependency(
     "poisson_reg_offset",
     eng = "glm_offset",
     pkg = "poissonreg",
-    mode = "regression")
+    mode = "regression"
+  )
   set_dependency(
     "poisson_reg_offset",
     eng = "glm_offset",
     pkg = "offsetreg",
-    mode = "regression")
+    mode = "regression"
+  )
 
   set_fit(
     model = "poisson_reg_offset",
@@ -56,12 +59,11 @@ make_poisson_reg_glm_offset <- function() {
       pre = .predict_pre_offset_rename,
       post = NULL,
       func = c(fun = "predict"),
-      args =
-        list(
-          object = expr(object$fit),
-          newdata = expr(new_data),
-          type = "response"
-        )
+      args = list(
+        object = expr(object$fit),
+        newdata = expr(new_data),
+        type = "response"
+      )
     )
   )
 
@@ -81,11 +83,11 @@ make_poisson_reg_glm_offset <- function() {
 
 
 make_poisson_reg_glmnet_offset <- function() {
-
   set_model_engine(
     "poisson_reg_offset",
     mode = "regression",
-    eng = "glmnet_offset")
+    eng = "glmnet_offset"
+  )
 
   set_dependency(
     "poisson_reg_offset",
@@ -163,9 +165,8 @@ make_poisson_reg_glmnet_offset <- function() {
       pre = .predict_pre_offset_rename,
       post = .organize_glmnet_pred,
       func = c(fun = "predict"),
-      args = c(pred_args,
-               type = "response",
-               s = expr(object$spec$args$penalty)))
+      args = c(pred_args, type = "response", s = expr(object$spec$args$penalty))
+    )
   )
 
   set_pred(

--- a/R/poisson_reg_offset.R
+++ b/R/poisson_reg_offset.R
@@ -24,7 +24,7 @@ poisson_reg_offset <- function(
   engine = "glm_offset"
 ) {
   if (mode != "regression") {
-    rlang::abort("`mode` should be 'regression'")
+    cli::cli_abort("`mode` should be 'regression'")
   }
 
   args <- list(penalty = rlang::enquo(penalty), mixture = rlang::enquo(mixture))
@@ -67,13 +67,13 @@ check_args.poisson_reg_offset <- function(object, call = NULL) {
   args <- lapply(object$args, rlang::eval_tidy)
 
   if (all(is.numeric(args$penalty)) && any(args$penalty < 0)) {
-    rlang::abort("The amount of regularization should be >= 0.")
+    cli::cli_abort("The amount of regularization should be >= 0.")
   }
   if (is.numeric(args$mixture) && (args$mixture < 0 | args$mixture > 1)) {
-    rlang::abort("The mixture proportion should be within [0,1].")
+    cli::cli_abort("The mixture proportion should be within [0,1].")
   }
   if (is.numeric(args$mixture) && length(args$mixture) > 1) {
-    rlang::abort("Only one value of `mixture` is allowed.")
+    cli::cli_abort("Only one value of `mixture` is allowed.")
   }
 
   invisible(object)

--- a/R/poisson_reg_offset.R
+++ b/R/poisson_reg_offset.R
@@ -17,15 +17,17 @@
 #' @inheritParams parsnip::poisson_reg
 #' @seealso [parsnip::poisson_reg()]
 #' @export
-poisson_reg_offset <- function(mode = "regression", penalty = NULL,
-                               mixture = NULL, engine = "glm_offset") {
-
-  if (mode  != "regression") {
+poisson_reg_offset <- function(
+  mode = "regression",
+  penalty = NULL,
+  mixture = NULL,
+  engine = "glm_offset"
+) {
+  if (mode != "regression") {
     rlang::abort("`mode` should be 'regression'")
   }
 
-  args <- list(penalty = rlang::enquo(penalty),
-               mixture = rlang::enquo(mixture))
+  args <- list(penalty = rlang::enquo(penalty), mixture = rlang::enquo(mixture))
 
   # Save some empty slots for future parts of the specification
   new_model_spec(
@@ -49,7 +51,7 @@ make_poisson_reg_offset <- function() {
 
 # code from the parsnip package
 #' @export
-translate.poisson_reg_offset <- function (x, engine = x$engine, ...) {
+translate.poisson_reg_offset <- function(x, engine = x$engine, ...) {
   x <- translate.default(x, engine, ...)
   if (engine == "glmnet_offset") {
     .check_glmnet_penalty_fit(x)
@@ -62,26 +64,31 @@ translate.poisson_reg_offset <- function (x, engine = x$engine, ...) {
 # code from the parsnip package
 #' @export
 check_args.poisson_reg_offset <- function(object, call = NULL) {
-
   args <- lapply(object$args, rlang::eval_tidy)
 
-  if (all(is.numeric(args$penalty)) && any(args$penalty < 0))
+  if (all(is.numeric(args$penalty)) && any(args$penalty < 0)) {
     rlang::abort("The amount of regularization should be >= 0.")
-  if (is.numeric(args$mixture) && (args$mixture < 0 | args$mixture > 1))
+  }
+  if (is.numeric(args$mixture) && (args$mixture < 0 | args$mixture > 1)) {
     rlang::abort("The mixture proportion should be within [0,1].")
-  if (is.numeric(args$mixture) && length(args$mixture) > 1)
+  }
+  if (is.numeric(args$mixture) && length(args$mixture) > 1) {
     rlang::abort("Only one value of `mixture` is allowed.")
+  }
 
   invisible(object)
 }
 
 # code from the parsnip package
 #' @export
-update.poisson_reg_offset <- function(object,
-                                      parameters = NULL,
-                                      penalty = NULL, mixture = NULL,
-                                      fresh = FALSE, ...) {
-
+update.poisson_reg_offset <- function(
+  object,
+  parameters = NULL,
+  penalty = NULL,
+  mixture = NULL,
+  fresh = FALSE,
+  ...
+) {
   args <- list(
     penalty = rlang::enquo(penalty),
     mixture = rlang::enquo(mixture)

--- a/R/rpart.R
+++ b/R/rpart.R
@@ -57,10 +57,10 @@ rpart_exposure <- function(
   rlang::check_installed("rpart")
 
   if (!is.data.frame(data)) {
-    rlang::abort("`data` must be a data frame.")
+    cli::cli_abort("`data` must be a data frame.")
   }
   if (!exposure_col %in% names(data)) {
-    rlang::abort(glue("A column named `{exposure_col}` must be present."))
+    cli::cli_abort("A column named `{exposure_col}` must be present.")
   }
 
   # rename the exposure column
@@ -88,10 +88,9 @@ rpart_exposure <- function(
 # internal function
 .formula_cbind_left <- function(formula) {
   if (length(formula[[2]]) > 1) {
-    rlang::abort(paste0(
-      "The left-hand side of `formula` must contain a single",
-      " response variable."
-    ))
+    cli::cli_abort(
+      "The left-hand side of `formula` must contain a single response variable."
+    )
   }
   formula_str <- as.character(formula)
   glue("cbind(exposure, {formula_str[[2]]}) ~ {formula_str[[3]]}") |>

--- a/R/rpart.R
+++ b/R/rpart.R
@@ -35,8 +35,11 @@
 #'
 #' @examples
 #' if (interactive()) {
-#'   rpart_exposure(deaths ~ age_group + gender, us_deaths,
-#'                  exposure_col = "population")
+#'   rpart_exposure(
+#'     deaths ~ age_group + gender,
+#'     us_deaths,
+#'     exposure_col = "population"
+#'   )
 #' }
 #'
 #' @seealso [rpart::rpart()]

--- a/R/rpart.R
+++ b/R/rpart.R
@@ -41,10 +41,16 @@
 #'
 #' @seealso [rpart::rpart()]
 #' @export
-rpart_exposure <- function(formula, data,
-                           exposure_col = "exposure", weights = NULL,
-                           control, cost, shrink = 1, ...) {
-
+rpart_exposure <- function(
+  formula,
+  data,
+  exposure_col = "exposure",
+  weights = NULL,
+  control,
+  cost,
+  shrink = 1,
+  ...
+) {
   rlang::check_installed("rpart")
 
   if (!is.data.frame(data)) {
@@ -64,17 +70,25 @@ rpart_exposure <- function(formula, data,
   # bind weights to the formula's environment to avoid an error in model.frame
   rlang::env_bind(environment(formula), weights = weights)
 
-  rpart::rpart(formula, data = data, weights = weights,
-               parms = list(shrink = shrink), cost = cost, control = control,
-               method = "poisson", ...)
-
+  rpart::rpart(
+    formula,
+    data = data,
+    weights = weights,
+    parms = list(shrink = shrink),
+    cost = cost,
+    control = control,
+    method = "poisson",
+    ...
+  )
 }
 
 # internal function
 .formula_cbind_left <- function(formula) {
   if (length(formula[[2]]) > 1) {
-    rlang::abort(paste0("The left-hand side of `formula` must contain a single",
-                        " response variable."))
+    rlang::abort(paste0(
+      "The left-hand side of `formula` must contain a single",
+      " response variable."
+    ))
   }
   formula_str <- as.character(formula)
   glue("cbind(exposure, {formula_str[[2]]}) ~ {formula_str[[3]]}") |>

--- a/R/xgboost.R
+++ b/R/xgboost.R
@@ -33,11 +33,23 @@
 #'
 #' @export
 xgb_train_offset <- function(
-    x, y, offset_col = "offset", weights = NULL,
-    max_depth = 6, nrounds = 15, eta  = 0.3, colsample_bynode = NULL,
-    colsample_bytree = NULL, min_child_weight = 1, gamma = 0, subsample = 1,
-    validation = 0, early_stop = NULL, counts = TRUE, ...) {
-
+  x,
+  y,
+  offset_col = "offset",
+  weights = NULL,
+  max_depth = 6,
+  nrounds = 15,
+  eta = 0.3,
+  colsample_bynode = NULL,
+  colsample_bytree = NULL,
+  min_child_weight = 1,
+  gamma = 0,
+  subsample = 1,
+  validation = 0,
+  early_stop = NULL,
+  counts = TRUE,
+  ...
+) {
   rlang::check_installed("xgboost")
 
   others <- list(...)
@@ -48,7 +60,7 @@ xgb_train_offset <- function(
 
   if (!is.null(early_stop)) {
     if (early_stop <= 1) {
-      rlang::abort(paste0("`early_stop` should be on [2, ",  nrounds, ")."))
+      rlang::abort(paste0("`early_stop` should be on [2, ", nrounds, ")."))
     } else if (early_stop >= nrounds) {
       early_stop <- nrounds - 1
       rlang::warn(paste0("`early_stop` was reduced to ", early_stop, "."))
@@ -59,10 +71,13 @@ xgb_train_offset <- function(
   # subtract one column for the offset
   p <- ncol(x) - 1L
 
-  x <- as_xgb_data_offset(x, y, offset_col,
-                          validation = validation,
-                          weights = weights)
-
+  x <- as_xgb_data_offset(
+    x,
+    y,
+    offset_col,
+    validation = validation,
+    weights = weights
+  )
 
   if (!is.numeric(subsample) || subsample < 0 || subsample > 1) {
     rlang::abort("`subsample` should be on [0, 1].")
@@ -81,8 +96,14 @@ xgb_train_offset <- function(
   }
 
   if (min_child_weight > n) {
-    msg <- paste0(min_child_weight, " samples were requested but there were ",
-                  n, " rows in the data. ", n, " will be used.")
+    msg <- paste0(
+      min_child_weight,
+      " samples were requested but there were ",
+      n,
+      " rows in the data. ",
+      n,
+      " will be used."
+    )
     rlang::warn(msg)
     min_child_weight <- min(min_child_weight, n)
   }
@@ -117,9 +138,13 @@ xgb_train_offset <- function(
 }
 
 # Original code from parsnip - modified for offsets
-as_xgb_data_offset <- function(x, y, offset_col,
-                               validation = 0, weights = NULL) {
-
+as_xgb_data_offset <- function(
+  x,
+  y,
+  offset_col,
+  validation = 0,
+  weights = NULL
+) {
   n <- nrow(x)
 
   if (is.data.frame(x)) {
@@ -150,8 +175,7 @@ as_xgb_data_offset <- function(x, y, offset_col,
       )
       watch_list <- list(validation = val_data)
 
-      info_list <- list(label = y[trn_index],
-                        base_margin = offsets[trn_index])
+      info_list <- list(label = y[trn_index], base_margin = offsets[trn_index])
       if (!is.null(weights)) {
         info_list$weight <- weights[trn_index]
       }
@@ -160,7 +184,6 @@ as_xgb_data_offset <- function(x, y, offset_col,
         missing = NA,
         info = info_list
       )
-
     } else {
       info_list <- list(label = y, base_margin = offsets)
       if (!is.null(weights)) {
@@ -199,8 +222,11 @@ recalc_param <- function(x, counts, denom) {
 maybe_proportion <- function(x, nm) {
   if (x < 1) {
     msg <- paste0(
-      "The option `counts = TRUE` was used but parameter `", nm,
-      "` was given as ", signif(x, 3), ". Please use a value >= 1 or use ",
+      "The option `counts = TRUE` was used but parameter `",
+      nm,
+      "` was given as ",
+      signif(x, 3),
+      ". Please use a value >= 1 or use ",
       "`counts = FALSE`."
     )
     rlang::abort(msg)
@@ -209,16 +235,17 @@ maybe_proportion <- function(x, nm) {
 
 # code from the parsnip package with small edits
 process_others <- function(others, arg_list) {
-
   guarded <- c("data", "weights", "watchlist", "objective")
   guarded_supplied <- names(others)[names(others) %in% guarded]
 
   n <- length(guarded_supplied)
   if (n > 0) {
     rlang::warn(
-      c("!" = glue(
-        "The following arguments are guarded and will not be passed to ",
-        "`xgb.train()`: {paste(guarded_supplied, collapse = ', ')}.")
+      c(
+        "!" = glue(
+          "The following arguments are guarded and will not be passed to ",
+          "`xgb.train()`: {paste(guarded_supplied, collapse = ', ')}."
+        )
       ),
       class = "xgboost_guarded_warning"
     )
@@ -228,9 +255,12 @@ process_others <- function(others, arg_list) {
 
   if (!is.null(others$params)) {
     rlang::warn(
-      c("!" = paste0("Please supply elements of the `params` list argument as ",
-                     "main arguments to `set_engine()` rather than as part of ",
-                     "`params`.")
+      c(
+        "!" = paste0(
+          "Please supply elements of the `params` list argument as ",
+          "main arguments to `set_engine()` rather than as part of ",
+          "`params`."
+        )
       ),
       class = "xgboost_params_warning"
     )
@@ -249,17 +279,17 @@ process_others <- function(others, arg_list) {
 #' @rdname xgb_train_offset
 #' @export
 xgb_predict_offset <- function(object, new_data, offset_col = "offset", ...) {
-
   if (!inherits(new_data, "xgb.DMatrix")) {
     new_data <- maybe_matrix(new_data) |>
       as_xgb_data_offset(offset_col = offset_col)
   } else {
     if (is.null(xgboost::getinfo(new_data, "base_margin"))) {
-      rlang::abort(paste0("If `new_data` is an `xgb.DMatrix`, it must have an ",
-                          "offset (base_margin) defined."))
+      rlang::abort(paste0(
+        "If `new_data` is an `xgb.DMatrix`, it must have an ",
+        "offset (base_margin) defined."
+      ))
     }
   }
 
   stats::predict(object, new_data, ...)
-
 }

--- a/R/xgboost.R
+++ b/R/xgboost.R
@@ -60,15 +60,15 @@ xgb_train_offset <- function(
   others <- list(...)
 
   if (!is.numeric(validation) || validation < 0 || validation >= 1) {
-    rlang::abort("`validation` should be on [0, 1).")
+    cli::cli_abort("`validation` should be on [0, 1).")
   }
 
   if (!is.null(early_stop)) {
     if (early_stop <= 1) {
-      rlang::abort(paste0("`early_stop` should be on [2, ", nrounds, ")."))
+      cli::cli_abort("`early_stop` should be on [2, {nrounds}).")
     } else if (early_stop >= nrounds) {
       early_stop <- nrounds - 1
-      rlang::warn(paste0("`early_stop` was reduced to ", early_stop, "."))
+      cli::cli_warn("`early_stop` was reduced to {early_stop}.")
     }
   }
 
@@ -85,7 +85,7 @@ xgb_train_offset <- function(
   )
 
   if (!is.numeric(subsample) || subsample < 0 || subsample > 1) {
-    rlang::abort("`subsample` should be on [0, 1].")
+    cli::cli_abort("`subsample` should be on [0, 1].")
   }
 
   # initialize
@@ -101,15 +101,10 @@ xgb_train_offset <- function(
   }
 
   if (min_child_weight > n) {
-    msg <- paste0(
-      min_child_weight,
-      " samples were requested but there were ",
-      n,
-      " rows in the data. ",
-      n,
-      " will be used."
-    )
-    rlang::warn(msg)
+    cli::cli_warn(paste0(
+      "{min_child_weight} samples were requested but there were ",
+      "{n} rows in the data. {n} will be used."
+    ))
     min_child_weight <- min(min_child_weight, n)
   }
 
@@ -162,7 +157,7 @@ as_xgb_data_offset <- function(
   }
 
   if (!offset_col %in% colnames(x)) {
-    rlang::abort(glue("A column named `{offset_col}` must be present."))
+    cli::cli_abort("A column named `{offset_col}` must be present.")
   }
   offsets <- x[, offset_col]
   x <- x[, !colnames(x) %in% offset_col, drop = FALSE]
@@ -231,15 +226,13 @@ recalc_param <- function(x, counts, denom) {
 # code from the parsnip package
 maybe_proportion <- function(x, nm) {
   if (x < 1) {
-    msg <- paste0(
-      "The option `counts = TRUE` was used but parameter `",
-      nm,
-      "` was given as ",
-      signif(x, 3),
-      ". Please use a value >= 1 or use ",
-      "`counts = FALSE`."
-    )
-    rlang::abort(msg)
+    cli::cli_abort(c(
+      paste0(
+        "The option `counts = TRUE` was used but parameter `{nm}`",
+        " was given as {signif(x, 3)}."
+      ),
+      i = "Please use a value >= 1 or use `counts = FALSE`."
+    ))
   }
 }
 
@@ -250,11 +243,11 @@ process_others <- function(others, arg_list) {
 
   n <- length(guarded_supplied)
   if (n > 0) {
-    rlang::warn(
+    cli::cli_warn(
       c(
-        "!" = glue(
+        "!" = paste0(
           "The following arguments are guarded and will not be passed to ",
-          "`xgb.train()`: {paste(guarded_supplied, collapse = ', ')}."
+          "`xgb.train()`: {guarded_supplied}."
         )
       ),
       class = "xgboost_guarded_warning"
@@ -264,7 +257,7 @@ process_others <- function(others, arg_list) {
   others <- others[!(names(others) %in% guarded)]
 
   if (!is.null(others$params)) {
-    rlang::warn(
+    cli::cli_warn(
       c(
         "!" = paste0(
           "Please supply elements of the `params` list argument as ",
@@ -294,7 +287,7 @@ xgb_predict_offset <- function(object, new_data, offset_col = "offset", ...) {
       as_xgb_data_offset(offset_col = offset_col)
   } else {
     if (is.null(xgboost::getinfo(new_data, "base_margin"))) {
-      rlang::abort(paste0(
+      cli::cli_abort(paste0(
         "If `new_data` is an `xgb.DMatrix`, it must have an ",
         "offset (base_margin) defined."
       ))

--- a/R/xgboost.R
+++ b/R/xgboost.R
@@ -55,7 +55,7 @@ xgb_train_offset <- function(
   counts = TRUE,
   ...
 ) {
-  rlang::check_installed("xgboost")
+  rlang::check_installed("xgboost", version = "3.0.0")
 
   others <- list(...)
 
@@ -120,19 +120,24 @@ xgb_train_offset <- function(
     colsample_bytree = colsample_bytree,
     colsample_bynode = colsample_bynode,
     min_child_weight = min(min_child_weight, n),
-    subsample = subsample
+    subsample = subsample,
+    objective = "count:poisson"
   )
+
+  if ("nthread" %in% names(others)) {
+    arg_list[["nthread"]] <- others$nthread
+    others[["nthread"]] <- NULL
+  }
 
   others <- process_others(others, arg_list)
 
   main_args <- c(
     list(
       data = quote(x$data),
-      watchlist = quote(x$watchlist),
+      evals = quote(x$evals),
       params = arg_list,
       nrounds = nrounds,
-      early_stopping_rounds = early_stop,
-      objective = "count:poisson"
+      early_stopping_rounds = early_stop
     ),
     others
   )
@@ -164,7 +169,7 @@ as_xgb_data_offset <- function(
 
   # exit early for predictions where y's aren't supplied
   if (missing(y)) {
-    return(xgboost::xgb.DMatrix(x, info = list(base_margin = offsets)))
+    return(xgboost::xgb.DMatrix(x, base_margin = offsets))
   }
 
   if (!inherits(x, "xgb.DMatrix")) {
@@ -176,26 +181,26 @@ as_xgb_data_offset <- function(
         data = x[-trn_index, , drop = FALSE],
         label = y[-trn_index],
         missing = NA,
-        info = list(base_margin = offsets[-trn_index])
+        base_margin = offsets[-trn_index]
       )
-      watch_list <- list(validation = val_data)
+      evals <- list(validation = val_data)
 
-      info_list <- list(label = y[trn_index], base_margin = offsets[trn_index])
-      if (!is.null(weights)) {
-        info_list$weight <- weights[trn_index]
-      }
       dat <- xgboost::xgb.DMatrix(
         data = x[trn_index, , drop = FALSE],
         missing = NA,
-        info = info_list
+        label = y[trn_index],
+        base_margin = offsets[trn_index],
+        weight = weights[trn_index]
       )
     } else {
-      info_list <- list(label = y, base_margin = offsets)
-      if (!is.null(weights)) {
-        info_list$weight <- weights
-      }
-      dat <- xgboost::xgb.DMatrix(x, missing = NA, info = info_list)
-      watch_list <- list(training = dat)
+      dat <- xgboost::xgb.DMatrix(
+        x,
+        missing = NA,
+        label = y,
+        base_margin = offsets,
+        weight = weights
+      )
+      evals <- list(training = dat)
     }
   } else {
     dat <- xgboost::setinfo(x, "label", y)
@@ -203,10 +208,10 @@ as_xgb_data_offset <- function(
     if (!is.null(weights)) {
       dat <- xgboost::setinfo(x, "weight", weights)
     }
-    watch_list <- list(training = dat)
+    evals <- list(training = dat)
   }
 
-  list(data = dat, watchlist = watch_list)
+  list(data = dat, evals = evals)
 }
 
 # code from the parsnip package
@@ -240,7 +245,7 @@ maybe_proportion <- function(x, nm) {
 
 # code from the parsnip package with small edits
 process_others <- function(others, arg_list) {
-  guarded <- c("data", "weights", "watchlist", "objective")
+  guarded <- c("data", "weights", "evals", "objective")
   guarded_supplied <- names(others)[names(others) %in% guarded]
 
   n <- length(guarded_supplied)

--- a/R/xgboost.R
+++ b/R/xgboost.R
@@ -23,10 +23,15 @@
 #'   us_deaths$off <- log(us_deaths$population)
 #'   x <- model.matrix(~ age_group + gender + off, us_deaths)[, -1]
 #'
-#'   mod <- xgb_train_offset(x, us_deaths$deaths, "off",
-#'                           eta = 1, colsample_bynode = 1,
-#'                           max_depth = 2, nrounds = 25,
-#'                           counts = FALSE)
+#'   mod <- xgb_train_offset(
+#'       x, us_deaths$deaths,
+#'       "off",
+#'       eta = 1,
+#'       colsample_bynode = 1,
+#'       max_depth = 2,
+#'       nrounds = 25,
+#'       counts = FALSE
+#'   )
 #'
 #'   xgb_predict_offset(mod, x, "off")
 #' }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,7 +2,4 @@
 
 0 errors | 0 warnings | 0 notes
 
-This is a re-submission of version 1.1.1 with correction to us_deaths.Rd that 
-was identified in pre-checks (https://win-builder.r-project.org/incoming_pretest/offsetreg_1.1.1_20250223_150017/Windows/00check.log).
-A URL pointing to the CDC's website was changed from "http" to "https".
-Additionally, the number of threads was limited to 2 in testthat.R to fix a NOTE.
+This is an update of an existing package.

--- a/data-raw/us_deaths-raw.R
+++ b/data-raw/us_deaths-raw.R
@@ -3,19 +3,24 @@
 library(readr)
 library(dplyr)
 
-us_deaths <- read_tsv("data-raw/Multiple Cause of Death, 1999-2020.txt",
-                      col_types = cols_only(
-                        Gender = col_factor(),
-                        `Ten-Year Age Groups Code` = col_factor(),
-                        Year = col_integer(),
-                        Deaths = col_number(),
-                        Population = col_number()),
-                      n_max = 140L) |>
-  rename(gender = Gender,
-         age_group = `Ten-Year Age Groups Code`,
-         year = Year,
-         deaths = Deaths,
-         population = Population) |>
+us_deaths <- read_tsv(
+  "data-raw/Multiple Cause of Death, 1999-2020.txt",
+  col_types = cols_only(
+    Gender = col_factor(),
+    `Ten-Year Age Groups Code` = col_factor(),
+    Year = col_integer(),
+    Deaths = col_number(),
+    Population = col_number()
+  ),
+  n_max = 140L
+) |>
+  rename(
+    gender = Gender,
+    age_group = `Ten-Year Age Groups Code`,
+    year = Year,
+    deaths = Deaths,
+    population = Population
+  ) |>
   mutate(qx = deaths / population)
 
 usethis::use_data(us_deaths, overwrite = TRUE)

--- a/man/glm_offset.Rd
+++ b/man/glm_offset.Rd
@@ -50,8 +50,12 @@ details.
 \examples{
 if (interactive()) {
   us_deaths$off <- log(us_deaths$population)
-  glm_offset(deaths ~ age_group + gender, family = "poisson",
-             us_deaths, offset_col = "off")
+  glm_offset(
+    deaths ~ age_group + gender,
+    family = "poisson",
+    us_deaths,
+    offset_col = "off"
+  )
 }
 
 }

--- a/man/glm_offset.Rd
+++ b/man/glm_offset.Rd
@@ -9,7 +9,8 @@ glm_offset(
   family = "gaussian",
   data,
   offset_col = "offset",
-  weights = NULL
+  weights = NULL,
+  ...
 )
 }
 \arguments{
@@ -24,6 +25,8 @@ and error distribution.}
 offsets.}
 
 \item{weights}{Optional weights to use in the fitting process.}
+
+\item{...}{Additional named arguments passed to \code{\link[stats:glm]{stats::glm()}}.}
 }
 \value{
 A \code{glm} object. See \code{\link[stats:glm]{stats::glm()}} for full details.

--- a/man/glmnet_offset.Rd
+++ b/man/glmnet_offset.Rd
@@ -11,7 +11,8 @@ glmnet_offset(
   offset_col = "offset",
   weights = NULL,
   lambda = NULL,
-  alpha = 1
+  alpha = 1,
+  ...
 )
 }
 \arguments{
@@ -35,6 +36,8 @@ offsets.}
 \item \code{alpha = 1}: Pure lasso model
 \item \code{alpha = 0}: Pure ridge model
 }}
+
+\item{...}{Additional named arguments passed to \code{\link[glmnet:glmnet]{glmnet::glmnet()}}.}
 }
 \value{
 A \code{glmnet} object. See \code{\link[glmnet:glmnet]{glmnet::glmnet()}} for full details.

--- a/man/rpart_exposure.Rd
+++ b/man/rpart_exposure.Rd
@@ -60,8 +60,11 @@ details.
 }
 \examples{
 if (interactive()) {
-  rpart_exposure(deaths ~ age_group + gender, us_deaths,
-                 exposure_col = "population")
+  rpart_exposure(
+    deaths ~ age_group + gender,
+    us_deaths,
+    exposure_col = "population"
+  )
 }
 
 }

--- a/man/xgb_train_offset.Rd
+++ b/man/xgb_train_offset.Rd
@@ -93,10 +93,15 @@ if (interactive()) {
   us_deaths$off <- log(us_deaths$population)
   x <- model.matrix(~ age_group + gender + off, us_deaths)[, -1]
 
-  mod <- xgb_train_offset(x, us_deaths$deaths, "off",
-                          eta = 1, colsample_bynode = 1,
-                          max_depth = 2, nrounds = 25,
-                          counts = FALSE)
+  mod <- xgb_train_offset(
+      x, us_deaths$deaths,
+      "off",
+      eta = 1,
+      colsample_bynode = 1,
+      max_depth = 2,
+      nrounds = 25,
+      counts = FALSE
+  )
 
   xgb_predict_offset(mod, x, "off")
 }

--- a/tests/testthat/test-poisson.R
+++ b/tests/testthat/test-poisson.R
@@ -3,103 +3,137 @@ f <- deaths ~ gender + age_group + year
 f_off <- update(f, ~ . + off)
 y <- us_deaths$deaths
 x <- model.matrix(f, us_deaths)[, -1]
-x_off <- model.matrix(update(f, ~. + off), us_deaths)[, -1]
+x_off <- model.matrix(update(f, ~ . + off), us_deaths)[, -1]
 
 # base models
 glm_base <- glm(f, family = "poisson", us_deaths, offset = off)
-glmnet_base <- glmnet::glmnet(x, y, family = "poisson", offset = us_deaths$off,
-                              alpha = 0.25)
+glmnet_base <- glmnet::glmnet(
+  x,
+  y,
+  family = "poisson",
+  offset = us_deaths$off,
+  alpha = 0.25
+)
 
-rec <- recipes::recipe(deaths ~ gender + age_group + year + off,
-                       data = us_deaths) |>
+rec <- recipes::recipe(
+  deaths ~ gender + age_group + year + off,
+  data = us_deaths
+) |>
   recipes::step_rename(offset = off)
 
 test_that("Error checks trigger", {
-  expect_error(glm_offset(data = 1),
-               regexp = "`data` must be a data frame")
-  expect_error(glm_offset(deaths ~ age_group, data = us_deaths,
-                          offset_col = "x"),
-               regexp = "A column named `x` must be present")
-  expect_error(glmnet_offset(x_off, y, offset_col = "x"),
-               regexp = "A column named `x` must be present")
+  expect_error(glm_offset(data = 1), regexp = "`data` must be a data frame")
+  expect_error(
+    glm_offset(deaths ~ age_group, data = us_deaths, offset_col = "x"),
+    regexp = "A column named `x` must be present"
+  )
+  expect_error(
+    glmnet_offset(x_off, y, offset_col = "x"),
+    regexp = "A column named `x` must be present"
+  )
 })
 
 
 test_that("*_offset() models work", {
-
   # glm_offset
-  glm_off <- glm_offset(f, family = "poisson",
-                        us_deaths, offset_col = "off")
+  glm_off <- glm_offset(f, family = "poisson", us_deaths, offset_col = "off")
 
   expect_identical(predict(glm_base), predict(glm_off))
 
   # glmnet_offset
-  glmnet_off <- glmnet_offset(x_off, y, family = "poisson", offset_col = "off",
-                              alpha = 0.25)
+  glmnet_off <- glmnet_offset(
+    x_off,
+    y,
+    family = "poisson",
+    offset_col = "off",
+    alpha = 0.25
+  )
 
-
-  expect_identical(predict(glmnet_base, x, newoffset = us_deaths$off, s = 1E-5),
-                   predict(glmnet_off, x, newoffset = us_deaths$off, s = 1E-5))
-
+  expect_identical(
+    predict(glmnet_base, x, newoffset = us_deaths$off, s = 1E-5),
+    predict(glmnet_off, x, newoffset = us_deaths$off, s = 1E-5)
+  )
 })
 
 test_that("poisson_reg_offset() works", {
-
   # glm offset
   glm_off <- poisson_reg_offset() |>
     set_engine("glm_offset", offset_col = "off") |>
     fit(f, data = us_deaths)
-  expect_identical(predict(glm_base, type = 'response') |> unname(),
-                   predict(glm_off, us_deaths)$.pred)
-  expect_identical(predict(glm_base),
-                   predict(glm_off, us_deaths, type = "raw"))
+  expect_identical(
+    predict(glm_base, type = 'response') |> unname(),
+    predict(glm_off, us_deaths)$.pred
+  )
+  expect_identical(predict(glm_base), predict(glm_off, us_deaths, type = "raw"))
 
   # glmnet offset
   glmnet_off <- poisson_reg_offset(penalty = 1E-5, mixture = 0.25) |>
     set_engine("glmnet_offset", offset_col = "off") |>
     fit(f_off, data = us_deaths)
-  expect_identical(predict(glmnet_base, x, newoffset = us_deaths$off, s = 1E-5,
-                           type = 'response') |> as.numeric(),
-                   predict(glmnet_off, us_deaths)$.pred)
-  expect_identical(predict(glmnet_base, x, newoffset = us_deaths$off, s = 1E-5),
-                   predict(glmnet_off, us_deaths, type = "raw"))
-
+  expect_identical(
+    predict(
+      glmnet_base,
+      x,
+      newoffset = us_deaths$off,
+      s = 1E-5,
+      type = 'response'
+    ) |>
+      as.numeric(),
+    predict(glmnet_off, us_deaths)$.pred
+  )
+  expect_identical(
+    predict(glmnet_base, x, newoffset = us_deaths$off, s = 1E-5),
+    predict(glmnet_off, us_deaths, type = "raw")
+  )
 })
 
 test_that("poisson_reg_offset() works with recipes", {
-
   # glm offset
   glm_off <- workflows::workflow() |>
     workflows::add_recipe(rec) |>
     workflows::add_model(poisson_reg_offset() |> set_engine("glm_offset")) |>
     fit(data = us_deaths)
-  expect_identical(predict(glm_base, type = 'response') |> unname(),
-                   predict(glm_off, us_deaths)$.pred)
+  expect_identical(
+    predict(glm_base, type = 'response') |> unname(),
+    predict(glm_off, us_deaths)$.pred
+  )
 
   # glmnet offset
   rec <- rec |> recipes::step_dummy(recipes::all_nominal_predictors())
   glmnet_off <- workflows::workflow() |>
     workflows::add_recipe(rec) |>
-    workflows::add_model(poisson_reg_offset(penalty = 1E-5, mixture = 0.25) |>
-                           set_engine("glmnet_offset")) |>
+    workflows::add_model(
+      poisson_reg_offset(penalty = 1E-5, mixture = 0.25) |>
+        set_engine("glmnet_offset")
+    ) |>
     fit(data = us_deaths)
   # re-do the baseline glmnet fit - columns are in a different order after the
   # recipe
   x <- rec |> recipes::prep() |> recipes::juice() |> as.matrix()
   x <- x[, !colnames(x) %in% c("offset", "deaths")]
-  glmnet_base <- glmnet::glmnet(x, y, family = "poisson", offset = us_deaths$off,
-                                alpha = 0.25)
+  glmnet_base <- glmnet::glmnet(
+    x,
+    y,
+    family = "poisson",
+    offset = us_deaths$off,
+    alpha = 0.25
+  )
 
-  expect_identical(predict(glmnet_base, x, newoffset = us_deaths$off, s = 1E-5,
-                           type = 'response') |> as.numeric(),
-                   predict(glmnet_off, us_deaths)$.pred)
-
+  expect_identical(
+    predict(
+      glmnet_base,
+      x,
+      newoffset = us_deaths$off,
+      s = 1E-5,
+      type = 'response'
+    ) |>
+      as.numeric(),
+    predict(glmnet_off, us_deaths)$.pred
+  )
 })
 
 test_that("finalize works", {
-
-  mod_spec <- poisson_reg_offset(penalty = tune(),
-                                 mixture = tune()) |>
+  mod_spec <- poisson_reg_offset(penalty = tune(), mixture = tune()) |>
     set_engine("glmnet_offset")
 
   rec <- rec |> recipes::step_dummy(recipes::all_nominal_predictors())
@@ -112,8 +146,9 @@ test_that("finalize works", {
 
   expect_no_error(tune::finalize_workflow(wf, param_grid) |> fit(us_deaths))
 
-  expect_equal(tune::finalize_model(mod_spec, param_grid)$args |>
-                 lapply(rlang::eval_tidy),
-               list(penalty = 0.005, mixture =0.9))
-
+  expect_equal(
+    tune::finalize_model(mod_spec, param_grid)$args |>
+      lapply(rlang::eval_tidy),
+    list(penalty = 0.005, mixture = 0.9)
+  )
 })

--- a/tests/testthat/test-poisson.R
+++ b/tests/testthat/test-poisson.R
@@ -152,3 +152,25 @@ test_that("finalize works", {
     list(penalty = 0.005, mixture = 0.9)
   )
 })
+
+test_that("... arguments work", {
+  # check the intercpet argument for glmnet_offset
+  no_int <- glmnet_offset(
+    x_off,
+    y,
+    family = "poisson",
+    offset_col = "off",
+    alpha = 0.25,
+    intercept = FALSE
+  )
+
+  no_int2 <- poisson_reg_offset(penalty = 1E-5, mixture = 0.25) |>
+    set_engine("glmnet_offset", offset_col = "off", intercept = FALSE) |>
+    fit(f_off, data = us_deaths)
+
+  expect_equal(coef(no_int, s = 1E-5)["(Intercept)", ], 0)
+  expect_equal(
+    coef(no_int, s = 1E-5),
+    extract_fit_engine(no_int2) |> coef(s = 1E-5)
+  )
+})

--- a/tests/testthat/test-rpart.R
+++ b/tests/testthat/test-rpart.R
@@ -2,22 +2,33 @@
 f <- deaths ~ gender + age_group + year
 
 test_that("Error checks trigger", {
-  expect_error(rpart_exposure(data = 1),
-               regexp = "`data` must be a data frame")
-  expect_error(rpart_exposure(deaths ~ age_group, data = us_deaths,
-                              exposure_col = "x"),
-               regexp = "A column named `x` must be present")
-  expect_error(rpart_exposure(cbind(deaths, population) ~ age_group,
-                              data = us_deaths,
-                              exposure_col = "population"),
-               regexp = "The left-hand side of `formula`")
+  expect_error(rpart_exposure(data = 1), regexp = "`data` must be a data frame")
+  expect_error(
+    rpart_exposure(deaths ~ age_group, data = us_deaths, exposure_col = "x"),
+    regexp = "A column named `x` must be present"
+  )
+  expect_error(
+    rpart_exposure(
+      cbind(deaths, population) ~ age_group,
+      data = us_deaths,
+      exposure_col = "population"
+    ),
+    regexp = "The left-hand side of `formula`"
+  )
 })
 
 rpart_base <- rpart::rpart(
   cbind(population, deaths) ~ gender + age_group + year,
-  data = us_deaths, method = 'poisson', cp = 0.01)
-rpart_expo <- rpart_exposure(f, exposure_col = "population",
-                             data = us_deaths, cp = 0.01)
+  data = us_deaths,
+  method = 'poisson',
+  cp = 0.01
+)
+rpart_expo <- rpart_exposure(
+  f,
+  exposure_col = "population",
+  data = us_deaths,
+  cp = 0.01
+)
 
 test_that("rpart_exposure() model works", {
   expect_identical(predict(rpart_base), predict(rpart_expo))
@@ -25,65 +36,86 @@ test_that("rpart_exposure() model works", {
 
 test_that("control and ... return identical results", {
   rpart_expo_ctrl <- rpart_exposure(
-    f, exposure_col = "population",
+    f,
+    exposure_col = "population",
     data = us_deaths,
-    control = rpart::rpart.control(cp = 0.001, maxdepth = 3, minsplit = 4))
-  rpart_expo_dots <- rpart_exposure(f, exposure_col = "population",
-                                    data = us_deaths,
-                                    cp = 0.001, maxdepth = 3, minsplit = 4)
+    control = rpart::rpart.control(cp = 0.001, maxdepth = 3, minsplit = 4)
+  )
+  rpart_expo_dots <- rpart_exposure(
+    f,
+    exposure_col = "population",
+    data = us_deaths,
+    cp = 0.001,
+    maxdepth = 3,
+    minsplit = 4
+  )
 
   expect_identical(predict(rpart_expo_ctrl), predict(rpart_expo_dots))
 })
 
 test_that("weights and costs work", {
-  rpart_wt <- rpart_exposure(f, exposure_col = "population",
-                             data = us_deaths, cp = 0.01,
-                             weights = us_deaths$population)
+  rpart_wt <- rpart_exposure(
+    f,
+    exposure_col = "population",
+    data = us_deaths,
+    cp = 0.01,
+    weights = us_deaths$population
+  )
   expect_false(identical(predict(rpart_expo), predict(rpart_wt)))
 
-  rpart_costs <- rpart_exposure(f, exposure_col = "population",
-                                data = us_deaths, cp = 0.01,
-                                cost = c(1, 100, 1))
+  rpart_costs <- rpart_exposure(
+    f,
+    exposure_col = "population",
+    data = us_deaths,
+    cp = 0.01,
+    cost = c(1, 100, 1)
+  )
   expect_false(identical(predict(rpart_expo), predict(rpart_costs)))
-
 })
 
 test_that("decision_tree_exposure() works", {
-
   # rpart_exposure
   rpart_expo <- decision_tree_exposure() |>
     set_engine("rpart_exposure", exposure_col = "population") |>
     fit(f, data = us_deaths)
-  expect_identical(predict(rpart_base) |> unname(),
-                   predict(rpart_expo, us_deaths)$.pred)
-  expect_identical(predict(rpart_base),
-                   predict(rpart_expo, us_deaths, type = "raw"))
-
+  expect_identical(
+    predict(rpart_base) |> unname(),
+    predict(rpart_expo, us_deaths)$.pred
+  )
+  expect_identical(
+    predict(rpart_base),
+    predict(rpart_expo, us_deaths, type = "raw")
+  )
 })
 
 
-rec <- recipes::recipe(deaths ~ gender + age_group + year + population,
-                       data = us_deaths) |>
+rec <- recipes::recipe(
+  deaths ~ gender + age_group + year + population,
+  data = us_deaths
+) |>
   recipes::step_rename(exposure = population)
 
 test_that("decision_tree_exposure() works with recipes", {
-
   # rpart_exposure
   rpart_expo <- workflows::workflow() |>
     workflows::add_recipe(rec) |>
-    workflows::add_model(decision_tree_exposure() |>
-                           set_engine("rpart_exposure")) |>
+    workflows::add_model(
+      decision_tree_exposure() |>
+        set_engine("rpart_exposure")
+    ) |>
     fit(data = us_deaths)
-  expect_identical(predict(rpart_base) |> unname(),
-                   predict(rpart_expo, us_deaths)$.pred)
-
+  expect_identical(
+    predict(rpart_base) |> unname(),
+    predict(rpart_expo, us_deaths)$.pred
+  )
 })
 
 test_that("finalize works", {
-
-  mod_spec <- decision_tree_exposure(cost_complexity = tune(),
-                                     tree_depth = tune(),
-                                     min_n = tune()) |>
+  mod_spec <- decision_tree_exposure(
+    cost_complexity = tune(),
+    tree_depth = tune(),
+    min_n = tune()
+  ) |>
     set_engine("rpart_exposure")
 
   wf <- workflows::workflow() |>
@@ -94,8 +126,9 @@ test_that("finalize works", {
 
   expect_no_error(tune::finalize_workflow(wf, param_grid) |> fit(us_deaths))
 
-  expect_equal(tune::finalize_model(mod_spec, param_grid)$args |>
-                 lapply(rlang::eval_tidy),
-               as.list(param_grid))
-
+  expect_equal(
+    tune::finalize_model(mod_spec, param_grid)$args |>
+      lapply(rlang::eval_tidy),
+    as.list(param_grid)
+  )
 })

--- a/tests/testthat/test-xgboost.R
+++ b/tests/testthat/test-xgboost.R
@@ -9,14 +9,16 @@ us_deaths2 <- recipes::recipe(~ age_group + gender + year + off, us_deaths) |>
 
 x <- as.matrix(us_deaths2)
 
-xgtrain <- xgboost::xgb.DMatrix(x[, colnames(x) != "off"],
-                                label = us_deaths$deaths,
-                                base_margin = us_deaths$off)
+xgtrain <- xgboost::xgb.DMatrix(
+  x[, colnames(x) != "off"],
+  label = us_deaths$deaths,
+  base_margin = us_deaths$off
+)
 
 set.seed(42)
 mod <- xgboost::xgb.train(
   params = list(
-    objective  = "count:poisson",
+    objective = "count:poisson",
     eval_metric = "rmse",
     eta = 1,
     subsample = 1,
@@ -28,11 +30,18 @@ mod <- xgboost::xgb.train(
   nrounds = 25
 )
 
-mod2 <- xgb_train_offset(x,
-                         us_deaths$deaths, "off",
-                         eta = 1, subsample = 1, colsample_bynode = 1,
-                         min_child_weight = 1, max_depth = 2, nrounds = 25,
-                         counts = FALSE)
+mod2 <- xgb_train_offset(
+  x,
+  us_deaths$deaths,
+  "off",
+  eta = 1,
+  subsample = 1,
+  colsample_bynode = 1,
+  min_child_weight = 1,
+  max_depth = 2,
+  nrounds = 25,
+  counts = FALSE
+)
 
 test_that("xgb_train_offset matches xgboost", {
   expect_equal(predict(mod, xgtrain), predict(mod2, xgtrain))
@@ -41,50 +50,72 @@ test_that("xgb_train_offset matches xgboost", {
 })
 
 test_that("xgb_train_offset throws the correct errors and warnings", {
-  expect_error(xgb_train_offset(x, us_deaths$deaths, "off", validation = -1),
-               regexp = "`validation` should be")
-  expect_error(xgb_train_offset(x, us_deaths$deaths, "off", early_stop = 1),
-               regexp = "`early_stop` should be")
-  expect_warning(xgb_train_offset(x, us_deaths$deaths, "off", early_stop = 99),
-                 regexp = "`early_stop` was reduced to")
-  expect_error(xgb_train_offset(x, us_deaths$deaths, "off", subsample = 1.01),
-               regexp = "`subsample` should be")
-  expect_warning(xgb_train_offset(x, us_deaths$deaths, "off",
-                                  min_child_weight = 1E3),
-                 regexp = "1000 samples were requested")
-  expect_error(xgb_train_offset(x, us_deaths$deaths),
-               regexp = "A column named `offset` must be present")
-  expect_error(xgb_train_offset(x, us_deaths$deaths, "off",
-                                colsample_bynode = 0.5),
-               regexp = "Please use a value >= 1")
-  expect_warning(xgb_train_offset(x, us_deaths$deaths, "off",
-                                  objective = "reg:squarederror"),
-                 regexp = "The following arguments are guarded")
-  expect_warning(xgb_train_offset(x, us_deaths$deaths, "off",
-                                  params = list(eta = 1)),
-                 regexp = "Please supply elements of the `params` list")
-  expect_error(xgb_predict_offset(mod2, xgboost::xgb.DMatrix(x)),
-               regexp = "If `new_data` is an `xgb.DMatrix`,")
+  expect_error(
+    xgb_train_offset(x, us_deaths$deaths, "off", validation = -1),
+    regexp = "`validation` should be"
+  )
+  expect_error(
+    xgb_train_offset(x, us_deaths$deaths, "off", early_stop = 1),
+    regexp = "`early_stop` should be"
+  )
+  expect_warning(
+    xgb_train_offset(x, us_deaths$deaths, "off", early_stop = 99),
+    regexp = "`early_stop` was reduced to"
+  )
+  expect_error(
+    xgb_train_offset(x, us_deaths$deaths, "off", subsample = 1.01),
+    regexp = "`subsample` should be"
+  )
+  expect_warning(
+    xgb_train_offset(x, us_deaths$deaths, "off", min_child_weight = 1E3),
+    regexp = "1000 samples were requested"
+  )
+  expect_error(
+    xgb_train_offset(x, us_deaths$deaths),
+    regexp = "A column named `offset` must be present"
+  )
+  expect_error(
+    xgb_train_offset(x, us_deaths$deaths, "off", colsample_bynode = 0.5),
+    regexp = "Please use a value >= 1"
+  )
+  expect_warning(
+    xgb_train_offset(
+      x,
+      us_deaths$deaths,
+      "off",
+      objective = "reg:squarederror"
+    ),
+    regexp = "The following arguments are guarded"
+  )
+  expect_warning(
+    xgb_train_offset(x, us_deaths$deaths, "off", params = list(eta = 1)),
+    regexp = "Please supply elements of the `params` list"
+  )
+  expect_error(
+    xgb_predict_offset(mod2, xgboost::xgb.DMatrix(x)),
+    regexp = "If `new_data` is an `xgb.DMatrix`,"
+  )
 })
 
 # standard formula for testing
 f <- deaths ~ age_group + gender + year + off
 
 test_that("boost_tree_offset() works", {
-
-  xgb_off <- boost_tree_offset(learn_rate = 1,
-                               sample_size = 1,
-                               mtry = 11,
-                               min_n = 1,
-                               tree_depth = 2,
-                               trees = 25) |>
+  xgb_off <- boost_tree_offset(
+    learn_rate = 1,
+    sample_size = 1,
+    mtry = 11,
+    min_n = 1,
+    tree_depth = 2,
+    trees = 25
+  ) |>
     set_engine("xgboost_offset", offset_col = "off") |>
     fit(f, data = us_deaths)
-  expect_identical(predict(mod, xgtrain),
-                   predict(xgb_off, us_deaths)$.pred)
-  expect_identical(predict(mod, xgtrain),
-                   predict(xgb_off, us_deaths, type = "raw"))
-
+  expect_identical(predict(mod, xgtrain), predict(xgb_off, us_deaths)$.pred)
+  expect_identical(
+    predict(mod, xgtrain),
+    predict(xgb_off, us_deaths, type = "raw")
+  )
 })
 
 rec <- recipes::recipe(deaths ~ age_group + gender + year + off, us_deaths) |>
@@ -92,52 +123,57 @@ rec <- recipes::recipe(deaths ~ age_group + gender + year + off, us_deaths) |>
   recipes::step_rename(offset = off)
 
 test_that("boost_tree_offset() works with recipes", {
-
   # rpart_exposure
   xgb_off <- workflows::workflow() |>
     workflows::add_recipe(rec) |>
-    workflows::add_model(boost_tree_offset(learn_rate = 1,
-                                           sample_size = 1,
-                                           mtry = 11,
-                                           min_n = 1,
-                                           tree_depth = 2,
-                                           trees = 25) |>
-                           set_engine("xgboost_offset")) |>
+    workflows::add_model(
+      boost_tree_offset(
+        learn_rate = 1,
+        sample_size = 1,
+        mtry = 11,
+        min_n = 1,
+        tree_depth = 2,
+        trees = 25
+      ) |>
+        set_engine("xgboost_offset")
+    ) |>
     fit(data = us_deaths)
-  expect_identical(predict(mod, xgtrain),
-                   predict(xgb_off, us_deaths)$.pred)
-
+  expect_identical(predict(mod, xgtrain), predict(xgb_off, us_deaths)$.pred)
 })
 
 test_that("finalize works", {
-
-  mod_spec <- boost_tree_offset(mtry = tune(),
-                                trees = tune(),
-                                min_n = tune(),
-                                tree_depth = tune(),
-                                learn_rate = tune(),
-                                loss_reduction = tune(),
-                                sample_size = tune(),
-                                stop_iter = tune()) |>
+  mod_spec <- boost_tree_offset(
+    mtry = tune(),
+    trees = tune(),
+    min_n = tune(),
+    tree_depth = tune(),
+    learn_rate = tune(),
+    loss_reduction = tune(),
+    sample_size = tune(),
+    stop_iter = tune()
+  ) |>
     set_engine("xgboost_offset")
 
   wf <- workflows::workflow() |>
     workflows::add_model(mod_spec) |>
     workflows::add_recipe(rec)
 
-  param_grid <- data.frame(mtry = 4,
-                           trees = 11,
-                           min_n = 2,
-                           tree_depth = 3,
-                           learn_rate = 0.3,
-                           loss_reduction = 0,
-                           sample_size = 0.7,
-                           stop_iter = 7)
+  param_grid <- data.frame(
+    mtry = 4,
+    trees = 11,
+    min_n = 2,
+    tree_depth = 3,
+    learn_rate = 0.3,
+    loss_reduction = 0,
+    sample_size = 0.7,
+    stop_iter = 7
+  )
 
   expect_no_error(tune::finalize_workflow(wf, param_grid) |> fit(us_deaths))
 
-  expect_equal(tune::finalize_model(mod_spec, param_grid)$args |>
-                 lapply(rlang::eval_tidy),
-               as.list(param_grid))
-
+  expect_equal(
+    tune::finalize_model(mod_spec, param_grid)$args |>
+      lapply(rlang::eval_tidy),
+    as.list(param_grid)
+  )
 })


### PR DESCRIPTION
- Added support for additional named arguments passed to `stats::glm()` in `glm_offset()` and `glmnet::glmnet()` in `glmnet_offset()`.
- Updated the minimum required version of `xgboost` to 3.0 and made behind-the-scenes changes to accomodate its updated API.
- Added the `cli` package for warning and error messages.